### PR TITLE
Define new options for inference run command

### DIFF
--- a/src/run.ml
+++ b/src/run.ml
@@ -97,10 +97,28 @@ module RunSynth : Runner = struct
   open CommonOptions
   
   let timeout = ref None
+  let mc_vars = ref []
+  let mc_synth = ref false
+  let mc_synth_maxcover = ref false
 
   let speclist =
     [ "--poke", Arg.Unit (fun () -> Choose.choose := Choose.poke), " Use servois poke heuristic (default: simple)"
     ; "--poke2", Arg.Unit (fun () -> Choose.choose := Choose.poke2), " Use improved poke heuristic (default: simple)"
+    ; "--mcpeak-bisect", Arg.Unit (fun () -> mc_synth := true), "Use model counting based ranking with strategy <bisection>"
+    ; "--mcpeak-maxcover", Arg.Unit (fun () -> mc_synth := true; mc_synth_maxcover := true), "Use model counting based ranking with strategy <maximum-coverage>"
+    ; "--mcvars", Arg.String (fun bss -> 
+          mc_vars := String.split_on_char ';' bss 
+                     |> List.map (fun bs ->
+                         let bs = String.trim bs in
+                         let bs = String.sub bs 1 ((String.length bs) - 2) in
+                         match String.split_on_char ',' bs  with
+                         | t::vs::[] -> (t,
+                                         let vs = String.trim vs in
+                                         String.sub vs 1 ((String.length vs) - 2) 
+                                         |> String.split_on_char '|' 
+                                         |> List.map String.trim)
+                         | _ -> failwith "Incorrect format for vars option"
+                       )), "Variable bindings for MC"
     ; "--timeout", Arg.Float (fun f -> timeout := Some f), " Set time limit for execution"
     ] @ common_speclist |>
     Arg.align


### PR DESCRIPTION
Manually providing variables names and sorts required for running model counting queries, and
Selection of any of the two flavors of MC driven algorithm