### PR TITLE
Add |L| metric, fix Synth time, and new command option

### DIFF
--- a/src/mc_peak/lattice.ml
+++ b/src/mc_peak/lattice.ml
@@ -23,6 +23,8 @@ sig
 
   val list_of: v el t -> v list
 
+  val length: v el t -> int
+
   val find_opt: (v -> bool) -> v el t -> v option
 
   (* val add: v -> v el t -> v el t *)
@@ -168,11 +170,6 @@ struct
    
   let list_of: v el t -> v list  =
     fun l -> 
-    (* List.fold_right (fun (idk, el) acc ->
-     *     match el with
-     *     | Element {value = p; _} -> p::acc
-     *     | (Bottom _ | Top _) -> acc
-     *   ) (StoreM.bindings l) [] *)
     List.flatten @@ List.map (fun (_, el) ->
         match el with
         | Element {value = p; _} -> [p]
@@ -180,6 +177,14 @@ struct
 
   let bottom: v el t -> v el option = fun l -> StoreM.find_opt id_bottom l
   let top: v el t -> v el option = fun l -> StoreM.find_opt id_top l 
+
+  let length: v el t -> int = 
+    fun l -> 
+    let sz = StoreM.cardinal l in
+    match bottom l, top l with
+    | Some _, Some _ -> sz - 2
+    | (Some _, None | None, Some _) -> sz - 1
+    | None, None -> sz 
 
   let coveredbyset: v -> v el t -> v list = 
     fun a l -> 

--- a/src/run.ml
+++ b/src/run.ml
@@ -98,12 +98,14 @@ module RunSynth : Runner = struct
   
   let timeout = ref None
   let lattice = ref false
+  let stronger_pred_first = ref false
 
   let speclist =
     [ "--poke", Arg.Unit (fun () -> Choose.choose := Choose.poke), " Use servois poke heuristic (default: simple)"
     ; "--poke2", Arg.Unit (fun () -> Choose.choose := Choose.poke2), " Use improved poke heuristic (default: simple)"
-    ; "--mcpeak-bisect", Arg.Unit (fun () -> Choose.choose := Choose.mc_bisect), " Use model counting based synthesis with strategy: bisection"
-    ; "--mcpeak-maxcover", Arg.Unit (fun () -> Choose.choose := Choose.mc_max_cover), " Use model counting based synthesis with strategy: maximum-coverage"
+    ; "--mcpeak-bisect", Arg.Unit (fun () -> Choose.choose := Choose.mc_bisect), " Use model counting based synthesis with strategy: bisection"    
+    ; "--mcpeak-max", Arg.Unit (fun () -> Choose.choose := Choose.mc_max), " Use model counting based synthesis with strategy: maximum-coverage"
+    ; "--stronger-pred-first", Arg.Unit (fun () -> stronger_pred_first := true), " Choose stronger predicates first"
     ; "--lattice", Arg.Unit (fun () -> lattice := true), " Create and use lattice of predicate implication."
     ; "--timeout", Arg.Float (fun f -> timeout := Some f), " Set time limit for execution"
     ] @ common_speclist |>
@@ -124,7 +126,8 @@ module RunSynth : Runner = struct
       let synth_options = {
         Synth.default_synth_options with prover = get_prover ();
                                          timeout = !timeout;
-                                         lattice = !lattice
+                                         lattice = !lattice;
+                                         stronger_predicates_first = !stronger_pred_first;
       } in
       Synth.synth ~options:synth_options spec method1 method2
     in


### PR DESCRIPTION
* Show the number of predicates in lattice
* Time_synth now includes mc_queries time
* Lattice time is measured outside of synth-time
* Option '--stronger-pred-first' is available (default false)